### PR TITLE
Set correct values for allow_all, deny_all, and enforce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set correct values for `allow_all`, `deny_all`, and `enforce`.
+
 ## [0.0.2]
 
 ### Fixed

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -164,14 +164,14 @@ section {
           END
 
           attribute "allow_all" {
-            type        = bool # TODO: should it be string "TRUE"?
+            type        = bool
             description = <<-END
               Setting this to true means that all values are allowed. This field can be set only in `Policies` for list constraints.
             END
           }
 
           attribute "deny_all" {
-            type        = bool # TODO: should it be string "FALSE"?
+            type        = bool
             description = <<-END
               Setting this to true means that all values are denied. This field can be set only in Policies for list constraints.
             END

--- a/main.tf
+++ b/main.tf
@@ -12,9 +12,9 @@ resource "google_org_policy_policy" "policy" {
         for_each = try(spec.value.rules, [])
 
         content {
-          allow_all = try(rules.value.allow_all, null)
-          deny_all  = try(rules.value.deny_all, null)
-          enforce   = try(rules.value.enforce, null)
+          allow_all = try(rules.value.allow_all, null) != null ? rules.value.allow_all == true ? "TRUE" : null : null
+          deny_all  = try(rules.value.deny_all, null) != null ? rules.value.deny_all == true ? "TRUE" : null : null
+          enforce   = try(rules.value.enforce, null) != null ? rules.value.enforce == true ? "TRUE" : null : null
 
           dynamic "condition" {
             for_each = try([rules.value.condition], [])


### PR DESCRIPTION
Values for `allow_all`, `deny_all` and `enforce` must be strings rather than booleans. User facing API should expose booleans though